### PR TITLE
Add m4a audio file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Audio Text Analyzer
 
-A Node.js command-line tool that converts audio files (MP3/AAC) to text and performs comprehensive text analysis including summarization, keyword extraction, sentiment analysis, and more.
+A Node.js command-line tool that converts audio files (MP3/AAC/M4A) to text and performs comprehensive text analysis including summarization, keyword extraction, sentiment analysis, and more.
 
 ## Project Structure
 
@@ -68,6 +68,8 @@ source venv/bin/activate   # Linux/macOS
 ```bash
 # Convert audio to text (auto or specified language)
 node src/audioToText.js data/input/sample.mp3 -l en
+node src/audioToText.js data/input/sample.aac -l en
+node src/audioToText.js data/input/sample.m4a -l en
 
 # Save report and transcript
 node src/audioToText.js data/input/sample.mp3 -o data/output/analysis.txt
@@ -136,6 +138,7 @@ Available tasks:
 
 - MP3
 - AAC
+- M4A
 
 ## Supported Languages
 

--- a/src/audioToText.js
+++ b/src/audioToText.js
@@ -11,7 +11,7 @@ const parseCLIArgs = () => {
     program
         .name("audio-analyzer")
         .description("Convert audio to text and perform comprehensive analysis")
-        .argument("<file>", "Audio file path (MP3 or AAC)")
+        .argument("<file>", "Audio file path (MP3, AAC, or M4A)")
         .option("-o, --output <file>", "Output file for the report")
         .option("-l, --language <lang>", "Language code (e.g., en, it, fr, es, de)", "auto")
         .parse();

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -24,8 +24,8 @@ const validateAudioFile = (audioFile) => {
     }
 
     const ext = path.extname(audioFile).toLowerCase();
-    if (![".mp3", ".aac"].includes(ext)) {
-        throw new Error("Unsupported file format. Use MP3 or AAC files.");
+    if (![".mp3", ".aac", ".m4a"].includes(ext)) {
+        throw new Error("Unsupported file format. Use MP3, AAC, or M4A files.");
     }
 };
 


### PR DESCRIPTION
Add M4A audio file support to the `audioToText.js` script to expand compatible input formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2614096-9d8c-454e-85b0-976049c840d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2614096-9d8c-454e-85b0-976049c840d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

